### PR TITLE
Copy iptables (userspace) modules into the initramfs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tailscale-initramfs (0.4) UNRELEASED; urgency=medium
+
+  * Copy the iptables userspace modules into the initramfs, so that tailscale
+    is able to update iptables rules.
+
+ -- Paul Aurich <paul@darkrain42.org>  Thu, 16 May 2024 19:20:32 -0700
+
 tailscale-initramfs (0.3) unstable; urgency=medium
 
   * Configure resolv.conf in initramfs if it isn't already, so the tailscale

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,9 @@
 %:
 	dh $@
 
+execute_after_dh_install:
+	sed -i -e 's,@DEB_HOST_MULTIARCH@,$(DEB_HOST_MULTIARCH),g' debian/tailscale-initramfs/usr/share/initramfs-tools/hooks/tailscale
+
 execute_after_dh_fixperms:
 	chmod 600 debian/tailscale-initramfs/etc/tailscale/initramfs/config
 

--- a/hooks/tailscale
+++ b/hooks/tailscale
@@ -32,6 +32,10 @@ copy_exec /bin/ip bin
 copy_exec /usr/sbin/iptables sbin
 copy_exec /usr/sbin/ip6tables sbin
 
+for mod in /usr/lib/@DEB_HOST_MULTIARCH@/xtables/*.so; do
+    copy_exec "$mod"
+done
+
 copy_modules_dir kernel/net/ipv4/netfilter
 copy_modules_dir kernel/net/ipv6/netfilter
 copy_modules_dir kernel/net/netfilter


### PR DESCRIPTION
These are necessary for the iptables userspace to properly manage iptables rules otherwise tailscale complains, starting with:

2024/05/15 16:10:39 health("router"): error: adding [! -i tailscale0 -s 100.115.92.0/23 -j RETURN] in v4/filter/ts-input: running [/sbin/iptables -t filter -A ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN --wait]: exit status 2: iptables v1.8.10 (nf_tables): Chain 'RETURN' does not exist
Try `iptables -h' or 'iptables --help' for more information.